### PR TITLE
add skip_if_too_deep to test

### DIFF
--- a/tests/testthat/test-table_mmrmt01.R
+++ b/tests/testthat/test-table_mmrmt01.R
@@ -9,6 +9,7 @@ too_old_lme4 <- compareVersion(as.character(packageVersion("lme4")), "1.1.21") <
 mmrm_results <- if (too_old_lme4) {
   NULL
 } else {
+  skip_if_too_deep(5)
   fit_mmrm(
     vars = list(
       response = "FEV1",


### PR DESCRIPTION
closes part of https://github.com/insightsengineering/coredev-tasks/issues/232

Following this https://github.com/insightsengineering/tern.mmrm/pull/49/files, the tests still fail in `test-table_mmrmt01` since the `fit_mmrm` is not placed within `skip_if_too_deep` therefore I just added `skip_if_too_deep(5)` to the conditional of `fit_mmrm`.