### PR TITLE
152: Adapt to new `mmrm` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,21 +18,21 @@ URL: https://github.com/insightsengineering/tern.mmrm,
 BugReports: https://github.com/insightsengineering/tern.mmrm/issues
 Depends:
     R (>= 3.6),
-    tern (>= 0.7.10)
+    tern (>= 0.9)
 Imports:
     checkmate,
     cowplot,
     dplyr,
     emmeans (>= 1.6),
-    formatters (>= 0.3.3),
+    formatters (>= 0.5.4),
     generics,
     ggplot2,
     lifecycle,
     magrittr,
-    mmrm (>= 0.2.2),
+    mmrm (>= 0.3.5),
     parallelly,
     rlang,
-    rtables (>= 0.5.2),
+    rtables (>= 0.6.5),
     stats,
     tidyr
 Suggests:


### PR DESCRIPTION
closes https://github.com/insightsengineering/tern.mmrm/issues/152
