### PR TITLE
rm mmrm from staged.dependencies

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -11,9 +11,6 @@ upstream_repos:
   insightsengineering/rtables:
     repo: insightsengineering/rtables
     host: https://github.com
-  openpharma/mmrm:
-    repo: openpharma/mmrm
-    host: https://github.com
 downstream_repos:
   insightsengineering/teal.modules.clinical:
     repo: insightsengineering/teal.modules.clinical


### PR DESCRIPTION
See https://github.com/openpharma/mmrm/issues/375

Note that this is independent of the `tern.mmrm` CRAN release, because the yaml file is not part of the R package submission.