### PR TITLE
Add support for `verdepcheck` action

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,0 +1,28 @@
+---
+name: Scheduled 🕰️
+
+on:
+  schedule:
+    - cron: '45 3 * * 0'
+  workflow_dispatch:
+
+jobs:
+  dependency-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-strategy: ["min_cohort", "min_isolated", "release", "max"]
+    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@main
+    name: Dependency Test - ${{ matrix.test-strategy }} 🔢
+    secrets:
+      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+      GCHAT_WEBHOOK: ${{ secrets.GCHAT_WEBHOOK }}
+    with:
+      strategy: ${{ matrix.test-strategy }}
+      additional-env-vars: |
+        PKG_SYSREQS_DRY_RUN=true
+  branch-cleanup:
+    name: Branch Cleanup 🧹
+    uses: insightsengineering/r.pkg.template/.github/workflows/branch-cleanup.yaml@main
+    secrets:
+      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -2,6 +2,9 @@
 name: Scheduled 🕰️
 
 on:
+  push:
+    branches:
+      - 528-verdepcheck_support@main
   schedule:
     - cron: '45 3 * * 0'
   workflow_dispatch:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -2,9 +2,6 @@
 name: Scheduled 🕰️
 
 on:
-  push:
-    branches:
-      - 528-verdepcheck_support@main
   schedule:
     - cron: '45 3 * * 0'
   workflow_dispatch:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
     Matrix,
     rmarkdown (>= 2.19),
     testthat (>= 3.1),
-    vdiffr,
+    vdiffr (>= 1.0.7),
     withr (>= 2.0.0)
 VignetteBuilder:
     knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ VignetteBuilder:
 Config/Needs/verdepcheck:
     insightsengineering/tern, mllg/checkmate, wilkelab/cowplot,
     tidyverse/dplyr, rvlenth/emmeans, insightsengineering/formatters,
-    tidyverse/ggplot2, r-lib/lifecycle, r-lib/magrittr, openpharma/mmrm,
+    tidyverse/ggplot2, r-lib/lifecycle, tidyverse/magrittr, openpharma/mmrm,
     HenrikBengtsson/parallelly, r-lib/rlang, insightsengineering/rtables,
     tidyverse/tidyr, tidymodels/broom, yihui/knitr, gdemin/maditr, cran/Matrix,
     rstudio/rmarkdown, r-lib/testthat, r-lib/vdiffr, r-lib/withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     lifecycle (>= 0.2.0),
     magrittr,
     mmrm (>= 0.3.5),
-    parallelly,
+    parallelly (>= 1.25.0),
     rlang (>= 1.0.1),
     rtables (>= 0.6.6),
     stats,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ VignetteBuilder:
     knitr
 Config/Needs/verdepcheck:
     insightsengineering/tern, mllg/checkmate, wilkelab/cowplot,
-    tidyverse/dplyr, rvlenth/emmeans, insightsengineering/formatters,
+    tidyverse/dplyr, rvlenth/emmeans, insightsengineering/formatters, r-lib/generics,
     tidyverse/ggplot2, r-lib/lifecycle, tidyverse/magrittr, openpharma/mmrm,
     HenrikBengtsson/parallelly, r-lib/rlang, insightsengineering/rtables,
     tidyverse/tidyr, tidymodels/broom, yihui/knitr, gdemin/maditr, cran/Matrix,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     broom (>= 0.7.10),
     grid,
     knitr (>= 1.42),
-    maditr,
+    maditr (>= 0.7.1),
     Matrix,
     rmarkdown (>= 2.19),
     testthat (>= 3.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     broom (>= 0.7.10),
     grid,
     knitr (>= 1.42),
-    maditr (>= 0.7.4),
+    maditr (>= 0.8.1),
     Matrix,
     rmarkdown (>= 2.19),
     testthat (>= 3.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,33 +30,40 @@ Depends:
     R (>= 3.6),
     tern (>= 0.9.3)
 Imports:
-    checkmate,
+    checkmate (>= 3.0.4),
     cowplot,
-    dplyr,
+    dplyr (>= 1.1.0),
     emmeans (>= 1.6),
     formatters (>= 0.5.5),
     generics,
     ggplot2,
-    lifecycle,
+    lifecycle (>= 0.2.0),
     magrittr,
     mmrm (>= 0.3.5),
     parallelly,
-    rlang,
+    rlang (>= 1.0.1),
     rtables (>= 0.6.6),
     stats,
-    tidyr
+    tidyr (>= 0.8.3)
 Suggests:
-    broom,
+    broom (>= 0.7.10),
     grid,
-    knitr,
+    knitr (>= 1.42),
     maditr,
     Matrix,
-    rmarkdown,
+    rmarkdown (>= 2.19),
     testthat (>= 3.1),
     vdiffr,
     withr (>= 2.0.0)
 VignetteBuilder:
     knitr
+Config/Needs/verdepcheck:
+    insightsengineering/tern, mllg/checkmate, wilkelab/cowplot,
+    tidyverse/dplyr, rvlenth/emmeans, insightsengineering/formatters,
+    tidyverse/ggplot2, r-lib/lifecycle, r-lib/magrittr, openpharma/mmrm,
+    HenrikBengtsson/parallelly, r-lib/rlang, insightsengineering/rtables,
+    tidyverse/tidyr, tidymodels/broom, yihui/knitr, gdemin/maditr, cran/Matrix,
+    rstudio/rmarkdown, r-lib/testthat, r-lib/vdiffr, r-lib/withr
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     broom (>= 0.7.10),
     grid,
     knitr (>= 1.42),
-    maditr (>= 0.7.1),
+    maditr (>= 0.7.4),
     Matrix,
     rmarkdown (>= 2.19),
     testthat (>= 3.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Depends:
     R (>= 3.6),
     tern (>= 0.9.3)
 Imports:
-    checkmate (>= 3.0.4),
+    checkmate (>= 2.1.0),
     cowplot,
     dplyr (>= 1.1.0),
     emmeans (>= 1.6),


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/528

### Changes description

- Bumps `maditr` (`as.data.table` not being detected)
- Bumps `parallelly` due to API requirement (`omit` parameter)


#### Considerations

ℹ️ on `max` failing: 
- `cran/Matrix` max version requires R 4.4 and `max` strategy is failing

#### See

https://github.com/insightsengineering/tern.mmrm/actions/runs/8799136588

![image](https://github.com/insightsengineering/tern.mmrm/assets/211358/8a184191-e17e-4d58-bbb0-fa7bad0d8cba)
