### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Suggests:
     knitr (>= 1.42),
     maditr (>= 0.8.1),
     Matrix,
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     testthat (>= 3.1),
     vdiffr (>= 1.0.7),
     withr (>= 2.0.0)

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@
 
 `tern.mmrm` provides an interface for mixed model repeated measures (MMRM) within the
 [`tern`](https://insightsengineering.github.io/tern) framework
-to produce commonly used tables (using [`rtables`](https://roche.github.io/rtables)) and graphs.
+to produce commonly used tables (using [`rtables`](https://roche.github.io/rtables) and graphs.
 It builds on the R-package [`mmrm`](https://openpharma.github.io/mmrm/) for the actual MMRM calculations.
 
 ## When to use this package
 
-If you would like to use the [`tern`](https://insightsengineering.github.io/tern) framework for
+If you would like to use the [`tern`](https://insightsengineering.github.io/tern/) framework for
 tabulation and graphs, then this package is ideal for your MMRM fits.
 However if you use another reporting framework then it will be better to directly use
 [`mmrm`](https://openpharma.github.io/mmrm/) and perform the tabulation and plots differently.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It builds on the R-package [`mmrm`](https://openpharma.github.io/mmrm/) for the 
 
 ## When to use this package
 
-If you would like to use the [`tern`](https://insightsengineering.github.io/tern/) framework for
+If you would like to use the [`tern`](https://insightsengineering.github.io/tern/latest-tag/) framework for
 tabulation and graphs, then this package is ideal for your MMRM fits.
 However if you use another reporting framework then it will be better to directly use
 [`mmrm`](https://openpharma.github.io/mmrm/) and perform the tabulation and plots differently.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 `tern.mmrm` provides an interface for mixed model repeated measures (MMRM) within the
 [`tern`](https://insightsengineering.github.io/tern) framework
-to produce commonly used tables (using [`rtables`](https://roche.github.io/rtables) and graphs.
+to produce commonly used tables (using [`rtables`](https://insightsengineering.github.io/rtables/) and graphs.
 It builds on the R-package [`mmrm`](https://openpharma.github.io/mmrm/) for the actual MMRM calculations.
 
 ## When to use this package


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.