### PR TITLE
Replacing deprecated function

### DIFF
--- a/design/design_baseline_summary.Rmd
+++ b/design/design_baseline_summary.Rmd
@@ -67,7 +67,7 @@ b <- basic_table() %>%
   split_cols_by("group") %>%
   add_colcounts() %>%
   split_rows_by("days_grouped") %>%
-  summarize_vars("Reaction") %>%
+  analyze_vars("Reaction") %>%
   build_table(
     baseline_dat,
     alt_counts_df = dat_adsl


### PR DESCRIPTION
# Pull Request

Fixes [https://github.com/insightsengineering/biomarker-catalog/issues/65](https://github.com/insightsengineering/biomarker-catalog/issues/65)

The function summarize_vars() has been deprecated and no longer works. It was used in the R Markdown of this package. A new function analyze_vars() is a renamed version of summarize_vars(). All occurrences of the deprecated function in this package have been replaced in this pull request.